### PR TITLE
Slack notifier full support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'pushpop'
+gem 'pushpop', :git => 'git@github.com:pushpop-project/pushpop.git'
 gem 'slack-notifier'
 
 group :development, :test do

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -66,7 +66,7 @@ module Pushpop
     end
 
     def message(message)
-      self._message = message
+      self._message = ::Slack::Notifier::LinkFormatter.format(message)
     end
 
     def icon(icon)

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -17,6 +17,7 @@ module Pushpop
     attr_accessor :_icon
     attr_accessor :_icon_type
     attr_accessor :_attachments
+    attr_accessor :_unfurl
 
     def run(last_response=nil, step_responses=nil)
 
@@ -59,6 +60,10 @@ module Pushpop
         opts['attachments'] = _attachments
       end
 
+      if _unfurl
+        opts['unfurl_links'] = true
+      end
+
       return opts
     end
 
@@ -99,6 +104,10 @@ module Pushpop
       end
 
       self._icon
+    end
+
+    def unfurl(should = true)
+      self._unfurl = should
     end
 
     def configure(last_response=nil, step_responses=nil)

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -16,6 +16,7 @@ module Pushpop
     attr_accessor :_message
     attr_accessor :_icon
     attr_accessor :_icon_type
+    attr_accessor :_attachments
 
     def run(last_response=nil, step_responses=nil)
 
@@ -54,6 +55,10 @@ module Pushpop
         opts["icon_#{_icon_type}"] = _icon
       end
 
+      if _attachments
+        opts['attachments'] = _attachments
+      end
+
       return opts
     end
 
@@ -67,6 +72,12 @@ module Pushpop
 
     def message(message)
       self._message = ::Slack::Notifier::LinkFormatter.format(message)
+    end
+
+    def attachment(attachment)
+      self._attachments = [] unless self._attachments
+
+      self._attachments.push(attachment)
     end
 
     def icon(icon)

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -14,6 +14,8 @@ module Pushpop
     attr_accessor :_channel
     attr_accessor :_username
     attr_accessor :_message
+    attr_accessor :_icon
+    attr_accessor :_icon_type
 
     def run(last_response=nil, step_responses=nil)
 
@@ -48,6 +50,10 @@ module Pushpop
         opts['username'] = _username
       end
 
+      if _icon && _icon_type
+        opts["icon_#{_icon_type}"] = _icon
+      end
+
       return opts
     end
 
@@ -61,6 +67,27 @@ module Pushpop
 
     def message(message)
       self._message = message
+    end
+
+    def icon(icon)
+      if icon[0..3] == 'http'
+        self._icon_type = 'url'
+        self._icon = icon
+      else
+        self._icon_type = 'emoji'
+        self._icon = icon
+
+        # Make sure the emoji is wrapped in colons
+        if self._icon[0] != ':'
+          self._icon = ":#{self._icon}"
+        end
+
+        if self._icon[self._icon.length - 1] != ':'
+          self._icon = "#{self._icon}:"
+        end
+      end
+
+      self._icon
     end
 
     def configure(last_response=nil, step_responses=nil)

--- a/pushpop-slack.gemspec
+++ b/pushpop-slack.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email       = "joe@keen.io"
   s.homepage    = "https://github.com/pushpop-project/pushpop-slack"
   s.summary     = "Send messages to Slack via Pushpop!"
+  s.description = "pushpop-slack allows you to send messages to your slack channel inside of a Pushpop job"
 
   s.add_dependency "pushpop"
 

--- a/spec/pushpop-slack_spec.rb
+++ b/spec/pushpop-slack_spec.rb
@@ -62,4 +62,14 @@ describe Pushpop::Slack do
 
     expect(step.options['icon_emoji']).to eq(':ghost:')
   end
+
+  it 'should format links in the message' do
+    step = Pushpop::Slack.new do
+      message 'Check out [this link](https://keen.io) to Keen!'
+    end
+
+    step.configure
+
+    expect(step._message).to include('<https://keen.io|this link>')
+  end
 end

--- a/spec/pushpop-slack_spec.rb
+++ b/spec/pushpop-slack_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Pushpop::Slack do
   it 'should make sure there is a message' do
     step = Pushpop::Slack.new do
-      message 'test'
     end 
 
     expect{step.run}.to raise_error
@@ -11,17 +10,56 @@ describe Pushpop::Slack do
 
   it 'should prepend a # to the channel if its not there' do
     step = Pushpop::Slack.new do
+      message 'nothing'
       channel 'test'
     end
 
-    step.options['channel'].should eq('#test')
+    step.configure
+
+    expect(step.options['channel']).to eq('#test')
   end
 
   it 'should not prepend a # to the channel if its already there' do
     step = Pushpop::Slack.new do
+      message 'nothing'
       channel '#test'
     end
 
-    step.options['channel'].should eq('#test')
+    step.configure
+
+    expect(step.options['channel']).to eq('#test')
+  end
+
+  it 'should set URL icons' do
+      step = Pushpop::Slack.new do
+        message 'nothing'
+        icon 'https://keen.io/file.png'
+      end
+
+      step.configure
+
+      expect(step.options["icon_url"]).to eq("https://keen.io/file.png")
+  end
+
+  it 'should set emoji icons' do
+    step = Pushpop::Slack.new do
+      message 'nothing'
+      icon ':ghost:'
+    end
+
+    step.configure
+
+    expect(step.options['icon_emoji']).to eq(':ghost:')
+  end
+
+  it 'should set add colons to emoji icons' do
+    step = Pushpop::Slack.new do
+      message 'nothing'
+      icon 'ghost'
+    end
+
+    step.configure
+
+    expect(step.options['icon_emoji']).to eq(':ghost:')
   end
 end

--- a/spec/pushpop-slack_spec.rb
+++ b/spec/pushpop-slack_spec.rb
@@ -113,4 +113,15 @@ describe Pushpop::Slack do
 
     expect(step.options['attachments'].size).to eq(2)
   end
+
+  it 'unfurls links' do
+    step = Pushpop::Slack.new do
+      message 'nothing'
+      unfurl
+    end
+
+    step.configure
+
+    expect(step.options['unfurl_links']).to eq(true)
+  end
 end

--- a/spec/pushpop-slack_spec.rb
+++ b/spec/pushpop-slack_spec.rb
@@ -72,4 +72,45 @@ describe Pushpop::Slack do
 
     expect(step._message).to include('<https://keen.io|this link>')
   end
+
+  it 'sets attachments' do
+    step = Pushpop::Slack.new do
+      first_a = {
+        fallback: 'tester',
+        text: 'heyo',
+        color: 'good'
+      }
+
+      message 'nothing'
+      attachment first_a
+    end 
+
+    step.configure
+
+    expect(step.options['attachments'].size).to eq(1)
+  end
+
+  it 'sets multiple' do
+    step = Pushpop::Slack.new do
+      first_a = {
+        fallback: 'tester',
+        text: 'heyo',
+        color: 'good'
+      }
+
+      second_a = {
+        fallback: 'tester 2',
+        text: 'sup',
+        color: 'bad'
+      }
+
+      message 'nothing'
+      attachment first_a
+      attachment second_a
+    end 
+
+    step.configure
+
+    expect(step.options['attachments'].size).to eq(2)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $: << File.join(File.dirname(__FILE__), '../lib')
 
 require 'pushpop'
-require 'pushpop-plugin'
+require 'pushpop-slack'
 
 RSpec.configure do |config|
   config.before :each do


### PR DESCRIPTION
@hex337 

This adds full support for all of the useful features inside of [slack-notifier](https://github.com/stevenosloan/slack-notifier).

I will write a readme after this, but for now you can just see how to use everything from the specs