### PR TITLE
return what the user actually wanted to return

### DIFF
--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -21,14 +21,15 @@ module Pushpop
 
     def run(last_response=nil, step_responses=nil)
 
-      configure(last_response, step_responses)
+      ret = configure(last_response, step_responses)
 
       unless _message
        raise 'Please set the message to send to Slack'
       end
 
       send_message
-    
+
+      ret
     end
 
     def send_message

--- a/lib/pushpop-slack/version.rb
+++ b/lib/pushpop-slack/version.rb
@@ -1,5 +1,5 @@
 module Pushpop
   class Slack
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
@hex337 Right now slack steps return the result of the network request to slack.. generally that was successful, which means the user has no way of stopping subsequent steps after a slack step.

This updates it so the value actually returned by the user gets sent back to the job.