### PR TITLE
Less errors

### DIFF
--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -23,11 +23,9 @@ module Pushpop
 
       ret = configure(last_response, step_responses)
 
-      unless _message
-       raise 'Please set the message to send to Slack'
+      if _message
+        send_message
       end
-
-      send_message
 
       ret
     end

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -25,6 +25,8 @@ module Pushpop
 
       if _message
         send_message
+      else
+        Pushpop.logger.debug("No slack message sent - message was not set")
       end
 
       ret
@@ -35,6 +37,8 @@ module Pushpop
         notifier = ::Slack::Notifier.new WEBHOOK_URL
 
         notifier.ping _message, options
+      else
+        Pushpop.logger.debug("Could not send slack message - SLACK_WEBHOOK_URL is nil or empty")
       end
     end
 

--- a/lib/pushpop-slack.rb
+++ b/lib/pushpop-slack.rb
@@ -31,9 +31,11 @@ module Pushpop
     end
 
     def send_message
-      notifier = ::Slack::Notifier.new WEBHOOK_URL
+      unless WEBHOOK_URL.nil? || WEBHOOK_URL.empty?
+        notifier = ::Slack::Notifier.new WEBHOOK_URL
 
-      notifier.ping _message, options
+        notifier.ping _message, options
+      end
     end
 
     def options

--- a/spec/pushpop-slack_spec.rb
+++ b/spec/pushpop-slack_spec.rb
@@ -1,11 +1,26 @@
 require 'spec_helper'
 
 describe Pushpop::Slack do
-  it 'should make sure there is a message' do
+  it 'should not send if there is no message' do
     step = Pushpop::Slack.new do
     end 
 
-    expect{step.run}.to raise_error
+    expect(step).not_to receive(:send_message)
+
+    step.configure
+    step.run
+  end
+
+  it 'should send if there is a message' do
+    step = Pushpop::Slack.new do
+      message 'nothing'
+    end
+
+    allow(step).to receive(:send_message)
+    expect(step).to receive(:send_message)
+
+    step.configure
+    step.run
   end
 
   it 'should prepend a # to the channel if its not there' do


### PR DESCRIPTION
@hex337 

Right now things blow up if you run a slack step but don't actually set a message. That means you can't conditionally decide _not_ to send a message in that step.

This fixes that.